### PR TITLE
Make Google Windows VMs work as 'is_virtual'

### DIFF
--- a/lib/src/facts/windows/virtualization_resolver.cc
+++ b/lib/src/facts/windows/virtualization_resolver.cc
@@ -27,6 +27,7 @@ namespace facter { namespace facts { namespace windows {
             make_tuple("VMware",            string(vm::vmware)),
             make_tuple("KVM",               string(vm::kvm)),
             make_tuple("Bochs",             string(vm::bochs)),
+            make_tuple("Google",            string(vm::gce)),
         };
 
         auto vals = _wmi->query(wmi::computersystem, {wmi::manufacturer, wmi::model});


### PR DESCRIPTION
As noted in the subject - the manufacturer check was missed for Windows
Google VMs and the result is that you cannot use any more the meta-data
as is_virtual is set to False.
